### PR TITLE
don't change bash editing / remove set -o vi

### DIFF
--- a/ubsetup.sh
+++ b/ubsetup.sh
@@ -891,7 +891,6 @@ read -r -d '' TEXT_BashToolAliases <<- "EOTXT"
 	alias dstopall="docker kill $(docker ps -q)"
 	alias cleantf='find . -type f -name .terraform.lock* | xargs -I fl bash -c "cd \$( dirname fl ) && pwd && rm -rf .terraform*"'
 	stty -ixon # Disable xon/off flow control, as it clashes with history search (Ctrl-s)
-	set -o vi
 	# bind '\e[A:history-search-backward'
 	# bind '\e[B:history-search-forward'
 EOTXT


### PR DESCRIPTION
Too much of a personal pref to be in the default script and confusing for those that start using a terminal if they don't know it's been done. 